### PR TITLE
Tweak PrusaSlicer Profiles

### DIFF
--- a/Slicer Profiles/PrusaSlicer/prusaslicer_config_bundle.ini
+++ b/Slicer Profiles/PrusaSlicer/prusaslicer_config_bundle.ini
@@ -2517,31 +2517,31 @@ filament_max_volumetric_speed = 21
 [filament:Generic ABS @Prusawire 0.25]
 inherits = *ABS*
 filament_max_volumetric_speed = 7
-compatible_printers_condition = nozzle_diameter[0]==0.25 and !nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(Prusawire)/ and nozzle_diameter[0]==0.25 and !nozzle_high_flow[0]
 
 [filament:Generic ABS @Prusawire 0.3]
 inherits = *ABS*
 filament_max_volumetric_speed = 10
-compatible_printers_condition = nozzle_diameter[0]==0.3 and !nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(Prusawire)/ and nozzle_diameter[0]==0.3 and !nozzle_high_flow[0]
 
 [filament:Generic ABS @Prusawire 0.4]
 inherits = *ABS*
-compatible_printers_condition = nozzle_diameter[0]==0.4 and !nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(Prusawire)/ and nozzle_diameter[0]==0.4 and !nozzle_high_flow[0]
 
 [filament:Generic ABS @Prusawire 0.5]
 inherits = *ABS*
 filament_max_volumetric_speed = 16
-compatible_printers_condition = nozzle_diameter[0]==0.5 and !nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(Prusawire)/ and nozzle_diameter[0]==0.5 and !nozzle_high_flow[0]
 
 [filament:Generic ABS @Prusawire 0.6]
 inherits = *ABS*
 filament_max_volumetric_speed = 17
-compatible_printers_condition = nozzle_diameter[0]==0.6 and !nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(Prusawire)/ and nozzle_diameter[0]==0.6 and !nozzle_high_flow[0]
 
 [filament:Generic ABS @Prusawire 0.8]
 inherits = *ABS*
 filament_max_volumetric_speed = 18
-compatible_printers_condition = nozzle_diameter[0]==0.8 and !nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(Prusawire)/ and nozzle_diameter[0]==0.8 and !nozzle_high_flow[0]
 
 [filament:Generic ASA @Prusawire 0.25]
 inherits = Generic ABS @Prusawire 0.25
@@ -2570,134 +2570,134 @@ filament_type = ASA
 [filament:Generic PLA @Prusawire 0.25]
 inherits = *PLA*
 filament_max_volumetric_speed = 7
-compatible_printers_condition = nozzle_diameter[0]==0.25 and !nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(Prusawire)/ and nozzle_diameter[0]==0.25 and !nozzle_high_flow[0]
 
 [filament:Generic PLA @Prusawire 0.3]
 inherits = *PLA*
 filament_max_volumetric_speed = 10
-compatible_printers_condition = nozzle_diameter[0]==0.3 and !nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(Prusawire)/ and nozzle_diameter[0]==0.3 and !nozzle_high_flow[0]
 
 [filament:Generic PLA @Prusawire 0.4]
 inherits = *PLA*
-compatible_printers_condition = nozzle_diameter[0]==0.4 and !nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(Prusawire)/ and nozzle_diameter[0]==0.4 and !nozzle_high_flow[0]
 
 [filament:Generic PLA @Prusawire 0.5]
 inherits = *PLA*
 filament_max_volumetric_speed = 14
-compatible_printers_condition = nozzle_diameter[0]==0.5 and !nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(Prusawire)/ and nozzle_diameter[0]==0.5 and !nozzle_high_flow[0]
 
 [filament:Generic PLA @Prusawire 0.6]
 inherits = *PLA*
 filament_max_volumetric_speed = 15
-compatible_printers_condition = nozzle_diameter[0]==0.6 and !nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(Prusawire)/ and nozzle_diameter[0]==0.6 and !nozzle_high_flow[0]
 
 [filament:Generic PLA @Prusawire 0.8]
 inherits = *PLA*
 filament_max_volumetric_speed = 16
-compatible_printers_condition = nozzle_diameter[0]==0.8 and !nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(Prusawire)/ and nozzle_diameter[0]==0.8 and !nozzle_high_flow[0]
 
 [filament:Generic PETG @Prusawire 0.25]
 inherits = *PETG*
 filament_max_volumetric_speed = 8
-compatible_printers_condition = nozzle_diameter[0]==0.25 and !nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(Prusawire)/ and nozzle_diameter[0]==0.25 and !nozzle_high_flow[0]
 
 [filament:Generic PETG @Prusawire 0.3]
 inherits = *PETG*
 filament_max_volumetric_speed = 11
-compatible_printers_condition = nozzle_diameter[0]==0.3 and !nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(Prusawire)/ and nozzle_diameter[0]==0.3 and !nozzle_high_flow[0]
 
 [filament:Generic PETG @Prusawire 0.4]
 inherits = *PETG*
-compatible_printers_condition = nozzle_diameter[0]==0.4 and !nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(Prusawire)/ and nozzle_diameter[0]==0.4 and !nozzle_high_flow[0]
 
 [filament:Generic PETG @Prusawire 0.5]
 inherits = *PETG*
 filament_max_volumetric_speed = 18
-compatible_printers_condition = nozzle_diameter[0]==0.5 and !nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(Prusawire)/ and nozzle_diameter[0]==0.5 and !nozzle_high_flow[0]
 
 [filament:Generic PETG @Prusawire 0.6]
 inherits = *PETG*
 filament_max_volumetric_speed = 19
-compatible_printers_condition = nozzle_diameter[0]==0.6 and !nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(Prusawire)/ and nozzle_diameter[0]==0.6 and !nozzle_high_flow[0]
 
 [filament:Generic PETG @Prusawire 0.8]
 inherits = *PETG*
 filament_max_volumetric_speed = 20
-compatible_printers_condition = nozzle_diameter[0]==0.8 and !nozzle_high_flow[0]
+compatible_printers_condition = printer_model=~/(Prusawire)/ and nozzle_diameter[0]==0.8 and !nozzle_high_flow[0]
 
 [filament:Generic ABS @Prusawire HF0.4]
 inherits = *ABSHF*
-compatible_printers_condition = nozzle_high_flow[0] and nozzle_diameter[0]==0.4
+compatible_printers_condition = printer_model=~/(Prusawire)/ and nozzle_high_flow[0] and nozzle_diameter[0]==0.4
 
 [filament:Generic ABS @Prusawire HF0.5]
 inherits = Generic ABS @Prusawire HF0.4
 filament_max_volumetric_speed = 27
-compatible_printers_condition = nozzle_high_flow[0] and nozzle_diameter[0]==0.5
+compatible_printers_condition = printer_model=~/(Prusawire)/ and nozzle_high_flow[0] and nozzle_diameter[0]==0.5
 
 [filament:Generic ABS @Prusawire HF0.6]
 inherits = Generic ABS @Prusawire HF0.4
 filament_max_volumetric_speed = 29
-compatible_printers_condition = nozzle_high_flow[0] and nozzle_diameter[0]==0.6
+compatible_printers_condition = printer_model=~/(Prusawire)/ and nozzle_high_flow[0] and nozzle_diameter[0]==0.6
 
 [filament:Generic ABS @Prusawire HF0.8]
 inherits = Generic ABS @Prusawire HF0.4
 filament_max_volumetric_speed = 31
-compatible_printers_condition = nozzle_high_flow[0] and nozzle_diameter[0]==0.8
+compatible_printers_condition = printer_model=~/(Prusawire)/ and nozzle_high_flow[0] and nozzle_diameter[0]==0.8
 
 [filament:Generic ASA @Prusawire HF0.4]
 inherits = *ASAHF*
-compatible_printers_condition = nozzle_high_flow[0] and nozzle_diameter[0]==0.4
+compatible_printers_condition = printer_model=~/(Prusawire)/ and nozzle_high_flow[0] and nozzle_diameter[0]==0.4
 
 [filament:Generic ASA @Prusawire HF0.5]
 inherits = Generic ASA @Prusawire HF0.4
 filament_max_volumetric_speed = 27
-compatible_printers_condition = nozzle_high_flow[0] and nozzle_diameter[0]==0.5
+compatible_printers_condition = printer_model=~/(Prusawire)/ and nozzle_high_flow[0] and nozzle_diameter[0]==0.5
 
 [filament:Generic ASA @Prusawire HF0.6]
 inherits = Generic ASA @Prusawire HF0.4
 filament_max_volumetric_speed = 29
-compatible_printers_condition = nozzle_high_flow[0] and nozzle_diameter[0]==0.6
+compatible_printers_condition = printer_model=~/(Prusawire)/ and nozzle_high_flow[0] and nozzle_diameter[0]==0.6
 
 [filament:Generic ASA @Prusawire HF0.8]
 inherits = Generic ASA @Prusawire HF0.4
 filament_max_volumetric_speed = 31
-compatible_printers_condition = nozzle_high_flow[0] and nozzle_diameter[0]==0.8
+compatible_printers_condition = printer_model=~/(Prusawire)/ and nozzle_high_flow[0] and nozzle_diameter[0]==0.8
 
 [filament:Generic PETG @Prusawire HF0.4]
 inherits = *PETGHF*
-compatible_printers_condition = nozzle_high_flow[0] and nozzle_diameter[0]==0.4
+compatible_printers_condition = printer_model=~/(Prusawire)/ and nozzle_high_flow[0] and nozzle_diameter[0]==0.4
 
 [filament:Generic PETG @Prusawire HF0.5]
 inherits = Generic PETG @Prusawire HF0.4
 filament_max_volumetric_speed = 25
-compatible_printers_condition = nozzle_high_flow[0] and nozzle_diameter[0]==0.5
+compatible_printers_condition = printer_model=~/(Prusawire)/ and nozzle_high_flow[0] and nozzle_diameter[0]==0.5
 
 [filament:Generic PETG @Prusawire HF0.6]
 inherits = Generic PETG @Prusawire HF0.4
 filament_max_volumetric_speed = 27
-compatible_printers_condition = nozzle_high_flow[0] and nozzle_diameter[0]==0.6
+compatible_printers_condition = printer_model=~/(Prusawire)/ and nozzle_high_flow[0] and nozzle_diameter[0]==0.6
 
 [filament:Generic PETG @Prusawire HF0.8]
 inherits = Generic PETG @Prusawire HF0.4
 filament_max_volumetric_speed = 29
-compatible_printers_condition = nozzle_high_flow[0] and nozzle_diameter[0]==0.8
+compatible_printers_condition = printer_model=~/(Prusawire)/ and nozzle_high_flow[0] and nozzle_diameter[0]==0.8
 
 [filament:Generic PLA @Prusawire HF0.4]
 inherits = *PLAHF*
-compatible_printers_condition = nozzle_high_flow[0] and nozzle_diameter[0]==0.4
+compatible_printers_condition = printer_model=~/(Prusawire)/ and nozzle_high_flow[0] and nozzle_diameter[0]==0.4
 
 [filament:Generic PLA @Prusawire HF0.5]
 inherits = Generic PLA @Prusawire HF0.4
 filament_max_volumetric_speed = 24
-compatible_printers_condition = nozzle_high_flow[0] and nozzle_diameter[0]==0.5
+compatible_printers_condition = printer_model=~/(Prusawire)/ and nozzle_high_flow[0] and nozzle_diameter[0]==0.5
 
 [filament:Generic PLA @Prusawire HF0.6]
 inherits = Generic PLA @Prusawire HF0.4
 filament_max_volumetric_speed = 26
-compatible_printers_condition = nozzle_high_flow[0] and nozzle_diameter[0]==0.6
+compatible_printers_condition = printer_model=~/(Prusawire)/ and nozzle_high_flow[0] and nozzle_diameter[0]==0.6
 
 [filament:Generic PLA @Prusawire HF0.8]
 inherits = Generic PLA @Prusawire HF0.4
 filament_max_volumetric_speed = 28
-compatible_printers_condition = nozzle_high_flow[0] and nozzle_diameter[0]==0.8
+compatible_printers_condition = printer_model=~/(Prusawire)/ and nozzle_high_flow[0] and nozzle_diameter[0]==0.8
 

--- a/Slicer Profiles/PrusaSlicer/prusaslicer_config_bundle.ini
+++ b/Slicer Profiles/PrusaSlicer/prusaslicer_config_bundle.ini
@@ -1,4 +1,4 @@
-[printer_model:VS_MK52]
+[printer_model:Prusawire]
 name = Prusawire
 variants = HF0.4; HF0.5; HF0.6; HF0.8; 0.25; 0.3; 0.4; 0.5; 0.6; 0.8
 technology = FFF
@@ -2310,7 +2310,7 @@ max_print_height = 180
 
 [printer:Prusawire - 0.4mm Nozzle (High Flow)]
 inherits = *VORON_CORE_XY*; *VSW_COMMON*
-printer_model = VS_MK52
+printer_model = Prusawire
 printer_variant = HF0.4
 nozzle_diameter = 0.4
 nozzle_high_flow = 1
@@ -2347,7 +2347,7 @@ default_print_profile = 0.40mm Strength @PRUSAWIRE - HF0.8mm
 
 [printer:Prusawire - 0.25mm Nozzle]
 inherits = Prusawire - 0.4mm Nozzle (High Flow)
-printer_model = VS_MK52
+printer_model = Prusawire
 printer_variant = 0.25
 nozzle_diameter = 0.25
 nozzle_high_flow = 0

--- a/Slicer Profiles/PrusaSlicer/prusaslicer_config_bundle.ini
+++ b/Slicer Profiles/PrusaSlicer/prusaslicer_config_bundle.ini
@@ -84,7 +84,7 @@ raft_first_layer_density = 80%
 raft_first_layer_expansion = 3
 seam_position = aligned
 single_extruder_multi_material_priming = 0
-skirts = 2
+skirts = 0
 skirt_height = 2
 slice_closing_radius = 0.049
 small_perimeter_speed = 170
@@ -2457,7 +2457,7 @@ filament_density = 1.07
 
 [filament:*PETG*]
 inherits = *common*
-bed_temperature = 70
+bed_temperature = 90
 bridge_fan_speed = 100
 chamber_minimal_temperature = 0
 chamber_temperature = 35
@@ -2469,16 +2469,16 @@ fan_below_layer_time = 20
 filament_density = 1.27
 filament_max_volumetric_speed = 17
 filament_type = PETG
-first_layer_bed_temperature = 70
-first_layer_temperature = 240
+first_layer_bed_temperature = 85
+first_layer_temperature = 250
 full_fan_speed_layer = 5
 max_fan_speed = 30
 min_fan_speed = 20
-temperature = 245
+temperature = 250
 
 [filament:*PLA*]
 inherits = *common*
-bed_temperature = 55
+bed_temperature = 60
 bridge_fan_speed = 100
 chamber_minimal_temperature = 0
 chamber_temperature = 20
@@ -2491,12 +2491,12 @@ filament_density = 1.24
 filament_max_volumetric_speed = 13
 filament_type = PLA
 first_layer_bed_temperature = 60
-first_layer_temperature = 215
+first_layer_temperature = 230
 full_fan_speed_layer = 4
 max_fan_speed = 100
 min_fan_speed = 100
 slowdown_below_layer_time = 12
-temperature = 210
+temperature = 225
 
 [filament:*ABSHF*]
 inherits = *ABS*

--- a/Slicer Profiles/PrusaSlicer/prusaslicer_config_bundle.ini
+++ b/Slicer Profiles/PrusaSlicer/prusaslicer_config_bundle.ini
@@ -1,23 +1,3 @@
-# Printer profiles for Positron3D printers.
-# Source: https://github.com/Positron3D/PrusaSlicer-settings-non-prusa-fff
-
-[vendor]
-repo_id = non-prusa-fff
-# Vendor name will be shown by the Config Wizard.
-name = Positron3D
-# Configuration version of this file. Config file will only be installed, if the config_version differs.
-# This means, the server may force the PrusaSlicer configuration to be downgraded.
-config_version = 1.0.0
-# Where to get the updates from?
-# config_update_url = https://files.prusa3d.com/wp-content/uploads/repository/PrusaSlicer-settings-master/live/Positron3D/
-config_update_url = https://github.com/Positron3D/Prusawire
-
-##################################################
-# Prusawire
-# This is generated from the Voron Switchwire profiles with a few changes.
-# Source Voron Switchwire profiles: https://raw.githubusercontent.com/prusa3d/PrusaSlicer-settings-non-prusa-fff/refs/heads/main/Voron/3.0.0.ini
-##################################################
-
 [printer_model:VS_MK52]
 name = Prusawire
 variants = HF0.4; HF0.5; HF0.6; HF0.8; 0.25; 0.3; 0.4; 0.5; 0.6; 0.8

--- a/scripts/generate-profiles-prusaslicer.py
+++ b/scripts/generate-profiles-prusaslicer.py
@@ -24,7 +24,7 @@ replaceStrings = {
     ":VS_MK52": ":Prusawire",
     "@SWITCHWIRE": "@PRUSAWIRE",
     "@VORON2": "@VORON2_PRUSAWIRE_INHERITED", # Must be different to import, otherwise they are duplicates.
-    "printer_model=~/(V2_250|V2_300|V2_350|VT_250|VT_300|VT_350|V0_120|VS_MK52)/ and ": "",
+    "printer_model=~/(V2_250|V2_300|V2_350|VT_250|VT_300|VT_350|V0_120|VS_MK52)/": "printer_model=~/(Prusawire)/",
 }
 
 # Keys are the profiles names. Values are dictionaries with the property names to set with the given values.

--- a/scripts/generate-profiles-prusaslicer.py
+++ b/scripts/generate-profiles-prusaslicer.py
@@ -14,29 +14,6 @@ import urllib.request
 # Make sure this URL starts with "raw.githubusercontent", otherwise it might download an HTML page.
 sourceUrl = "https://raw.githubusercontent.com/prusa3d/PrusaSlicer-settings-non-prusa-fff/refs/heads/main/Voron/3.0.0.ini"
 
-# Block that is put at the top of the profiles file, including comments and the vendor block.
-headerBlock = """
-# Printer profiles for Positron3D printers.
-# Source: https://github.com/Positron3D/PrusaSlicer-settings-non-prusa-fff
-
-[vendor]
-repo_id = non-prusa-fff
-# Vendor name will be shown by the Config Wizard.
-name = Positron3D
-# Configuration version of this file. Config file will only be installed, if the config_version differs.
-# This means, the server may force the PrusaSlicer configuration to be downgraded.
-config_version = 1.0.0
-# Where to get the updates from?
-# config_update_url = https://files.prusa3d.com/wp-content/uploads/repository/PrusaSlicer-settings-master/live/Positron3D/
-config_update_url = https://github.com/Positron3D/Prusawire
-
-##################################################
-# Prusawire
-# This is generated from the Voron Switchwire profiles with a few changes.
-# Source Voron Switchwire profiles: %SOURCE_URL%
-##################################################
-"""
-
 # Keys are strings to find (section names, section values). Values are the strings to replace with.
 # In dictionaries, order is not guaranteed. Be careful of replaced values disrupting other keys!
 replaceStrings = {
@@ -158,5 +135,4 @@ for sectionName in profiles.sections():
 
 # Write the profiles.
 with open(targetProfilesLocation, "w", encoding="utf8") as file:
-    file.write(headerBlock.strip().replace("%SOURCE_URL%", sourceUrl) + "\n\n")
     outputProfiles.write(file)

--- a/scripts/generate-profiles-prusaslicer.py
+++ b/scripts/generate-profiles-prusaslicer.py
@@ -20,6 +20,7 @@ replaceStrings = {
     "VORON Switchwire": "Prusawire",
     "Voron": "Prusawire",
     "VORON_SWITCHWIRE": "PRUSAWIRE",
+    ":VS_MK52": ":Prusawire",
     "@SWITCHWIRE": "@PRUSAWIRE",
     "@VORON2": "@VORON2_PRUSAWIRE_INHERITED", # Must be different to import, otherwise they are duplicates.
     "printer_model=~/(V2_250|V2_300|V2_350|VT_250|VT_300|VT_350|V0_120|VS_MK52)/ and ": "",
@@ -31,6 +32,7 @@ replaceProperties = {
     "bed_model": "prusawire_build_plate.stl",
     "bed_texture": "prusawire_texture.svg",
     "thumbnail": "thumbnail_prusawire.png",
+    "printer_model": "Prusawire",
 }
 
 

--- a/scripts/generate-profiles-prusaslicer.py
+++ b/scripts/generate-profiles-prusaslicer.py
@@ -1,6 +1,7 @@
 """
 Generates Prusawire profiles from the Voron Switchwire profiles.
 The only major difference between the Voron Switchwire and Prusawire is the max build height.
+Some additional properties are set based on the Prusa MK4S, such as matching temperatures and disabling skirts.
 
 Usage: python3 generate-profiles-prusaslicer.py
 """
@@ -26,13 +27,39 @@ replaceStrings = {
     "printer_model=~/(V2_250|V2_300|V2_350|VT_250|VT_300|VT_350|V0_120|VS_MK52)/ and ": "",
 }
 
-# Keys are the property names in the profiles and values are the new values to use.
-replaceProperties = {
-    "max_print_height": "180",
-    "bed_model": "prusawire_build_plate.stl",
-    "bed_texture": "prusawire_texture.svg",
-    "thumbnail": "thumbnail_prusawire.png",
-    "printer_model": "Prusawire",
+# Keys are the profiles names. Values are dictionaries with the property names to set with the given values.
+# They will always be set, even if it isn't present otherwise.
+# The profile names must be the section name in the final name (ex: printer:Prusawire, not printer:VORON Switchwire)
+replacePropertiesBySection = {
+    "printer_model:Prusawire": {
+        "bed_model": "prusawire_build_plate.stl",
+        "bed_texture": "prusawire_texture.svg",
+        "thumbnail": "thumbnail_prusawire.png",
+    },
+    "print:*common*": {
+        "skirts": "0",
+    },
+    "printer:*VSW_COMMON*": {
+        "max_print_height": "180",
+    },
+    "printer:Prusawire - 0.4mm Nozzle (High Flow)": {
+        "printer_model": "Prusawire",
+    },
+    "printer:Prusawire - 0.25mm Nozzle": {
+        "printer_model": "Prusawire",
+    },
+    "filament:*PETG*": {
+        "first_layer_temperature": "250",
+        "temperature": "250",
+        "first_layer_bed_temperature": "85",
+        "bed_temperature": "90",
+    },
+    "filament:*PLA*": {
+        "first_layer_temperature": "230",
+        "temperature": "225",
+        "first_layer_bed_temperature": "60",
+        "bed_temperature": "60",
+    },
 }
 
 
@@ -127,6 +154,11 @@ for sectionName in profiles.sections():
     newSectionName = replaceString(sectionName)
     outputProfiles.add_section(newSectionName)
 
+    # Get the properties to replace for the section.
+    replaceProperties = {}
+    if newSectionName in replacePropertiesBySection.keys():
+        replaceProperties = replacePropertiesBySection[newSectionName]
+
     # Populate the section.
     section = profiles[sectionName]
     for key in section.keys():
@@ -134,6 +166,9 @@ for sectionName in profiles.sections():
             outputProfiles[newSectionName][key] = replaceProperties[key]
         else:
             outputProfiles[newSectionName][key] = replaceString(section[key])
+    for key in replaceProperties.keys():
+        if key not in section.keys():
+            outputProfiles[newSectionName][key] = replaceProperties[key]
 
 # Write the profiles.
 with open(targetProfilesLocation, "w", encoding="utf8") as file:


### PR DESCRIPTION
Closes #77

This pull request:
- Removes the vendor header, which is used for the configuration wizard. *This will be moved to a new script that merges the Positron and Prusawire profiles.*
- Changes `VS_MK52` to `Prusawire` for the file names to show Prusawire.
- Changes the PLA and PETG print temperatures to match the Prusa MK4S. PETG should warp a lot less.
- Disables skirts.
- Adds filament conditions to avoid loading with other printers when combined for PrusaSlicer (ex: Positron).